### PR TITLE
Enable CoreNEURON also in runSimWithIntervalFunc

### DIFF
--- a/netpyne/sim/run.py
+++ b/netpyne/sim/run.py
@@ -214,8 +214,15 @@ def runSimWithIntervalFunc(interval, func, timeRange=None, funcArgs=None):
     if type(funcArgs) == dict:
         kwargs.update(funcArgs)
 
-    if sim.rank == 0: 
-        print('\nRunning with interval func  ...')
+    if sim.cfg.coreneuron == True:
+        if sim.rank == 0: print('\nRunning with interval func using CoreNEURON for %s ms...'%sim.cfg.duration)
+        from neuron import coreneuron
+        coreneuron.enable = True
+        if sim.cfg.gpu == True:
+            coreneuron.gpu = True
+            coreneuron.cell_permute = 2
+    else:
+        if sim.rank == 0: print('\nRunning with interval func using NEURON for %s ms...'%sim.cfg.duration)
     
     if int(startTime) != 0:
         sim.pc.psolve(startTime)


### PR DESCRIPTION
This PR enables the CoreNEURON execution in the `runSimWithIntervalFunc` function similarly to `runSim` function.
Before merging maybe it's worth doing the following:
- [ ] Run and test with `runSimWithIntervalFunc()` and `CoreNEURON` and compare it with `NEURON`

Related to: https://github.com/suny-downstate-medical-center/netpyne/issues/611#issuecomment-1022307796