### PR TITLE
Update multicompartment reaction specification

### DIFF
--- a/examples/rxd_net/netParams.py
+++ b/examples/rxd_net/netParams.py
@@ -114,4 +114,4 @@ mcReactions['ip3r'] = {'reactant': 'ca[er]', 'product': 'ca[cyt]', 'rate_f': kip
 netParams.rxdParams['multicompartmentReactions'] = mcReactions
 
 ### rates
-netParams.rxdParams['rates'] = {'ip3rg': {'species': h_gate, 'rate': '(1. / (1 + 1000. * ca[cyt] / (0.3)) - %s) / ip3rtau'%(h_gate)}}
+netParams.rxdParams['rates'] = {'ip3rg': {'species': h_gate, 'rate': '(1. / (1 + 1000. * ca[cyt] / (0.3)) - %s) / ip3rtau'%(h_gate), 'regions' : ['cyt_er_membrane', 'cyt']}}

--- a/netpyne/network/netrxd.py
+++ b/netpyne/network/netrxd.py
@@ -48,7 +48,8 @@ def addRxD (self, nthreads=None):
     if len(self.params.rxdParams):
         try:
             global rxd
-            from neuron import crxd as rxd 
+            # from neuron import crxd as rxd 
+            from neuron import rxd 
             sim.net.rxd = {'species': {}, 'regions': {}}  # dictionary for rxd  
             if nthreads:
                 rxd.nthread(nthreads)
@@ -453,6 +454,7 @@ def _addReactions(self, params, multicompartment=False):
         # custom_dynamics
         if 'custom_dynamics' not in param:
             param['custom_dynamics'] = False
+
         if 'membrane_flux' not in param:
             param['membrane_flux'] = False
 
@@ -460,26 +462,58 @@ def _addReactions(self, params, multicompartment=False):
         if 'membrane_flux' not in param:
             param['membrane_flux'] = False
 
-        if rate_b is None and dynamicVars.get('rate_b', None) is None:
-            # omit positional argument 'rate_b'
-            self.rxd[reactionDictKey][label]['hObj'] = getattr(rxd, reactionStr)(dynamicVars['reactant'],
-                                                                            dynamicVars['product'],
-                                                                            dynamicVars['rate_f'] if 'rate_f' in dynamicVars else rate_f,
-                                                                            regions=nrnRegions,
-                                                                            custom_dynamics=param['custom_dynamics'],
-                                                                            membrane_flux=param['membrane_flux'],
-                                                                            membrane=nrnMembraneRegion)
+        # scale_by_area 
+        if 'scale_by_area' not in param:
+            param['scale_by_area'] = True #False
 
+        # mass action 
+        if 'mass_action' not in param:
+            param['mass_action'] = False
+
+        if multicompartment:
+            if rate_b is None and dynamicVars.get('rate_b', None) is None:
+                # omit positional argument 'rate_b'
+                self.rxd[reactionDictKey][label]['hObj'] = getattr(rxd, reactionStr)(dynamicVars['reactant'],
+                                                                                dynamicVars['product'],
+                                                                                dynamicVars['rate_f'] if 'rate_f' in dynamicVars else rate_f,
+                                                                                regions=nrnRegions,
+                                                                                custom_dynamics=param['custom_dynamics'],
+                                                                                membrane_flux=param['membrane_flux'],
+                                                                                membrane=nrnMembraneRegion,
+                                                                                scale_by_area=param['scale_by_area'])
+
+            else:
+                # include positional argument 'rate_b'
+                self.rxd[reactionDictKey][label]['hObj'] = getattr(rxd, reactionStr)(dynamicVars['reactant'],
+                                                                                dynamicVars['product'],
+                                                                                dynamicVars['rate_f'] if 'rate_f' in dynamicVars else rate_f,
+                                                                                dynamicVars['rate_b'] if 'rate_b' in dynamicVars else rate_b,
+                                                                                regions=nrnRegions,
+                                                                                custom_dynamics=param['custom_dynamics'],
+                                                                                membrane_flux=param['membrane_flux'],
+                                                                                membrane=nrnMembraneRegion,
+                                                                                scale_by_area=param['scale_by_area'])
         else:
-            # include positional argument 'rate_b'
-            self.rxd[reactionDictKey][label]['hObj'] = getattr(rxd, reactionStr)(dynamicVars['reactant'],
-                                                                            dynamicVars['product'],
-                                                                            dynamicVars['rate_f'] if 'rate_f' in dynamicVars else rate_f,
-                                                                            dynamicVars['rate_b'] if 'rate_b' in dynamicVars else rate_b,
-                                                                            regions=nrnRegions,
-                                                                            custom_dynamics=param['custom_dynamics'],
-                                                                            membrane_flux=param['membrane_flux'],
-                                                                            membrane=nrnMembraneRegion)
+            if rate_b is None and dynamicVars.get('rate_b', None) is None:
+                # omit positional argument 'rate_b'
+                self.rxd[reactionDictKey][label]['hObj'] = getattr(rxd, reactionStr)(dynamicVars['reactant'],
+                                                                                dynamicVars['product'],
+                                                                                dynamicVars['rate_f'] if 'rate_f' in dynamicVars else rate_f,
+                                                                                regions=nrnRegions,
+                                                                                custom_dynamics=param['custom_dynamics'],
+                                                                                membrane_flux=param['membrane_flux'],
+                                                                                membrane=nrnMembraneRegion)
+
+            else:
+                # include positional argument 'rate_b'
+                self.rxd[reactionDictKey][label]['hObj'] = getattr(rxd, reactionStr)(dynamicVars['reactant'],
+                                                                                dynamicVars['product'],
+                                                                                dynamicVars['rate_f'] if 'rate_f' in dynamicVars else rate_f,
+                                                                                dynamicVars['rate_b'] if 'rate_b' in dynamicVars else rate_b,
+                                                                                regions=nrnRegions,
+                                                                                custom_dynamics=param['custom_dynamics'],
+                                                                                membrane_flux=param['membrane_flux'],
+                                                                                membrane=nrnMembraneRegion)
 
 
         print('  Created %s %s'%(reactionStr, label))


### PR DESCRIPTION
Updated multicompartment reactrions in `netpyne/network/netrxd.py` to include `scale_by_area` (defaults `True` like NEURON) and `mass_action. Updated `examples/rxd_net/netParams.py` to specify relevant regions for rxd rates (currently defaults to `None`).