### PR TITLE
Fix issue #520 referenced by NetPyNE-UI

### DIFF
--- a/netpyne/metadata/metadata.py
+++ b/netpyne/metadata/metadata.py
@@ -1704,7 +1704,7 @@ metadata = {
             },
             "dt": {
                 "label": "Time step, dt",
-                "help": "Simulation time step in ms (default: 0.1)",
+                "help": "Simulation time step in ms (default: 0.025)",
                 "suggestions": "",
                 "default": 0.025,
                 "type": "float"


### PR DESCRIPTION
This PR closes issue [#520](https://github.com/MetaCell/NetPyNE-UI/issues/520) from NetPyNE-UI 

Fix bad simulation time step default value message in "metadata.py"