### PR TITLE
feat: unpin matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-matplotlib<=3.5.1
+matplotlib
 scipy
 pandas
 future

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ else:
         # your project is installed. For an analysis of "install_requires" vs pip's
         # requirements files see:
         # https://packaging.python.org/en/latest/requirements.html
-        install_requires=["numpy", "scipy", "matplotlib<=3.5.1", "matplotlib-scalebar", "future", "pandas", "bokeh", "schema", "lfpykit"],
+        install_requires=["numpy", "scipy", "matplotlib", "matplotlib-scalebar", "future", "pandas", "bokeh", "schema", "lfpykit"],
         # List additional groups of dependencies here (e.g. development
         # dependencies). You can install these using the following syntax,
         # for example:


### PR DESCRIPTION
Fixes #692

The old version of netpyne does not provide wheels for py3.11 etc.