### PR TITLE
Exlude tests from discovery / installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ else:
         keywords=["neuron", "network", "developing", "framework", "biological", "simulation"],
         # You can just specify the packages manually here if your project is
         # simple. Or you can use find_packages().
-        packages=find_packages(exclude=["saveLoadV1"]),
+        packages=find_packages(exclude=["saveLoadV1", "tests*"]),
         # List run-time dependencies here.  These will be installed by pip when
         # your project is installed. For an analysis of "install_requires" vs pip's
         # requirements files see:


### PR DESCRIPTION
Without it tests/ will be installed as a top level Python module.
