### PR TITLE
quick fix, setCfgMapping getattr check to hasattr

### DIFF
--- a/netpyne/specs/netParams.py
+++ b/netpyne/specs/netParams.py
@@ -846,5 +846,5 @@ class NetParams(object):
     def setCfgMapping(self, cfg):
         if hasattr(self, 'mapping'):
             for k, v in self.mapping.items():
-                if getattr(cfg, k, None):
+                if hasattr(cfg, k):
                     self.setNestedParam(v, getattr(cfg, k))


### PR DESCRIPTION
with getattr(cfg, k, None) unexpected behavior when value to map is equivalent to False (0, None, False, empty object)

#793 