### PR TITLE
create() output parameter order mismatch

### DIFF
--- a/netpyne/plotting/plotShape.py
+++ b/netpyne/plotting/plotShape.py
@@ -44,6 +44,7 @@ def plotShape(
     showElectrodes=False,
     synStyle='.',
     synSize=3,
+    synColor='tomato',
     dist=0.6,
     elev=90,
     azim=-90,
@@ -250,7 +251,7 @@ def plotShape(
 
         # Synapses
         if showSyns:
-            synColor = 'red'
+            # synColor = 'cyan'
             for cellPost in cellsPost:
                 for sec in list(cellPost.secs.values()):
                     for synMech in sec['synMechs']:
@@ -301,7 +302,7 @@ def plotShape(
                         filename = saveFig
                 else:
                     filename = sim.cfg.filename + '_shape.png'
-                plt.savefig(filename, dpi=dpi)
+                plt.savefig(filename, dpi=300)
 
             # show fig
             # if showFig: _showFigure()

--- a/netpyne/sim/wrappers.py
+++ b/netpyne/sim/wrappers.py
@@ -61,7 +61,7 @@ def create(netParams=None, simConfig=None, output=False, clearAll=False):
     simData = sim.setupRecording()  # setup variables to record for each cell (spikes, V traces, etc)
 
     if output:
-        return (pops, cells, conns, rxd, stims, simData)
+        return (pops, cells, conns, stims, rxd, simData)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
The output parameters of the create() function have been reordered to match the order when the function is called by switching `rxd` and `stims`. The original create() would return `(pops, cells, conns, rxd, stims, simData)` and the invocation would return `(pops, cells, conns, stims, rxd, simData)`.