### PR TITLE
fix(py312): remove `imp`

### DIFF
--- a/examples/netClamp/src/cfg.py
+++ b/examples/netClamp/src/cfg.py
@@ -1,4 +1,3 @@
-import imp
 from netpyne import specs
 
 # Simulation options

--- a/examples/rxd_buffering/src/netParams.py
+++ b/examples/rxd_buffering/src/netParams.py
@@ -1,4 +1,3 @@
-import imp
 from netpyne import specs
 
 netParams = specs.NetParams()  # object of class NetParams to store the network parameters

--- a/netpyne/batch/grid.py
+++ b/netpyne/batch/grid.py
@@ -24,7 +24,6 @@ except NameError:
     to_unicode = str
 
 import pandas as pd
-import imp
 import os, sys
 import glob
 from time import sleep


### PR DESCRIPTION
The `imp` module has been removed in Python 3.12:
https://docs.python.org/3/whatsnew/3.12.html#imp