### PR TITLE
define `cellInds` before reference in `syncLines` logic

### DIFF
--- a/netpyne/plotting/plotRaster.py
+++ b/netpyne/plotting/plotRaster.py
@@ -392,6 +392,7 @@ def plotRaster(
 
     # add spike lines
     if syncLines:
+        cellInds = list(set(spkInds))
         rasterPlotter.axis.vlines(spkTimes, 0, len(cellInds), 'red', linewidth=0.1)
 
     # add legend


### PR DESCRIPTION
hotfix regarding `syncLines`
