### PR TITLE
fixed bug in conn, updated test/examples/* to use dynamic pathing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 - cfg.connRandomSecFromList and cfg.distributeSynsUniformly can now be overriden in individual conn rule
 
+- Updated tests.examples.utils to allow for dynamic pathing
+
 **Bug fixes**
 
 - Better handling of exceptions in `importCellParams()` (incl. issue 782)

--- a/netpyne/network/conn.py
+++ b/netpyne/network/conn.py
@@ -511,7 +511,7 @@ def probConn(self, preCellsTags, postCellsTags, connParam):
     if sim.cfg.verbose:
         print('Generating set of probabilistic connections (rule: %s) ...' % (connParam['label']))
     if sim.rank == 0 and not sim.cfg.verbose: pbar = tqdm(total=len(postCellsTags.items()), ascii=True,
-                                  desc='  ' + connParam['label'], position=0, leave=True,
+                                  desc='  ' + str(connParam['label']), position=0, leave=True,
                                   bar_format= '{l_bar}{bar}| Creating synaptic connections for {n_fmt}/{total_fmt} postsynaptic cells on node %i (probabilistic connectivity)' % sim.rank)
 
     allRands = self.generateRandsPrePost(preCellsTags, postCellsTags)

--- a/tests/examples/test_HHTut.py
+++ b/tests/examples/test_HHTut.py
@@ -4,9 +4,10 @@ from netpyne import sim
 if '-nogui' not in sys.argv:
     sys.argv.append('-nogui')
 
-from .utils import pkg_setup
+from .utils import pkg_setup, NETPYNE_DIR
 
-@pytest.mark.package_data(['examples/HHTut/', None])
+package_dir = NETPYNE_DIR + '/examples/HHTut/'
+@pytest.mark.package_data([package_dir, None])
 class TestHHTut():
     def test_run(self, pkg_setup):
         import src.init

--- a/tests/examples/test_HybridTut.py
+++ b/tests/examples/test_HybridTut.py
@@ -5,9 +5,11 @@ from netpyne import sim
 if '-nogui' not in sys.argv:
     sys.argv.append('-nogui')
 
-from .utils import pkg_setup
+from .utils import pkg_setup, NETPYNE_DIR
 
-@pytest.mark.package_data(['examples/HybridTut/', 'mod'])
+package_dir = NETPYNE_DIR + '/examples/HybridTut/'
+
+@pytest.mark.package_data([package_dir, 'mod'])
 class TestHybridTut:
     def test_run(self, pkg_setup):
         import src.init

--- a/tests/examples/test_LFPrecording.py
+++ b/tests/examples/test_LFPrecording.py
@@ -5,10 +5,10 @@ import sys
 if '-nogui' not in sys.argv:
     sys.argv.append('-nogui')
 
-from .utils import pkg_setup
+from .utils import pkg_setup, NETPYNE_DIR
 
-
-@pytest.mark.package_data(['examples/LFPrecording/', 'mod'])
+package_dir = NETPYNE_DIR + '/examples/LFPrecording/'
+@pytest.mark.package_data([package_dir, 'mod'])
 class TestLFPrecording:
     def test_cell_lfp(self, pkg_setup):
         import src.cell.init

--- a/tests/examples/test_M1.py
+++ b/tests/examples/test_M1.py
@@ -5,10 +5,10 @@ from netpyne import sim
 if '-nogui' not in sys.argv:
     sys.argv.append('-nogui')
 
-from .utils import pkg_setup
+from .utils import pkg_setup, NETPYNE_DIR
 
-
-@pytest.mark.package_data(['examples/M1/', 'mod'])
+package_dir = NETPYNE_DIR + '/examples/M1/'
+@pytest.mark.package_data([package_dir, 'mod'])
 class TestM1:
     def test_run(self, pkg_setup):
         import src.init

--- a/tests/examples/test_NeuroMLImport.py
+++ b/tests/examples/test_NeuroMLImport.py
@@ -5,10 +5,10 @@ import sys
 if '-nogui' not in sys.argv:
     sys.argv.append('-nogui')
 
-from .utils import pkg_setup
+from .utils import pkg_setup, NETPYNE_DIR
 
-
-@pytest.mark.package_data(['examples/NeuroMLImport/', '.'])
+package_dir = NETPYNE_DIR + '/examples/NeuroMLImport/'
+@pytest.mark.package_data([package_dir, '.'])
 class TestPTcell:
     def test_init(self, pkg_setup):
         import SimpleNet_import

--- a/tests/examples/test_PTcell.py
+++ b/tests/examples/test_PTcell.py
@@ -5,10 +5,10 @@ import sys
 if '-nogui' not in sys.argv:
     sys.argv.append('-nogui')
 
-from .utils import pkg_setup
+from .utils import pkg_setup, NETPYNE_DIR
 
-
-@pytest.mark.package_data(['examples/PTcell/', 'mod'])
+package_dir = NETPYNE_DIR + '/examples/PTcell/'
+@pytest.mark.package_data([package_dir, 'mod'])
 class TestPTcell:
     def test_init(self, pkg_setup):
         import src.init

--- a/tests/examples/test_batchCell.py
+++ b/tests/examples/test_batchCell.py
@@ -8,10 +8,10 @@ from multiprocessing import Process
 if "-nogui" not in sys.argv:
     sys.argv.append("-nogui")
 
-from .utils import pkg_setup
+from .utils import pkg_setup, NETPYNE_DIR
 
-
-@pytest.mark.package_data(["examples/batchCell/", "mod"])
+package_dir = NETPYNE_DIR + "/examples/batchCell/"
+@pytest.mark.package_data([package_dir, "mod"])
 class TestBatchCell:
     def batch_run(self, pkg_setup):
         """run a reduced version of the batchCell example"""

--- a/tests/examples/test_evolCell.py
+++ b/tests/examples/test_evolCell.py
@@ -9,10 +9,10 @@ from multiprocessing import Process
 if "-nogui" not in sys.argv:
     sys.argv.append("-nogui")
 
-from .utils import pkg_setup
+from .utils import pkg_setup, NETPYNE_DIR
 
-
-@pytest.mark.package_data(["examples/evolCell/", "mod"])
+package_dir = NETPYNE_DIR + "/examples/evolCell/"
+@pytest.mark.package_data([package_dir, "mod"])
 class TestEvolCell:
     def evol_run(self, pkg_setup):
         """run a reduced version of the evolCell example"""

--- a/tests/examples/test_rxd_buffering.py
+++ b/tests/examples/test_rxd_buffering.py
@@ -3,9 +3,10 @@ import sys
 if '-nogui' not in sys.argv:
     sys.argv.append('-nogui')
 
-from .utils import pkg_setup
+from .utils import pkg_setup, NETPYNE_DIR
 
-@pytest.mark.package_data(['examples/rxd_buffering/', None])
+package_dir = NETPYNE_DIR + '/examples/rxd_buffering/'
+@pytest.mark.package_data([package_dir, None])
 class Test_rxd_buffering():
     def test_buffering(self, pkg_setup):
         import src.init

--- a/tests/examples/test_rxd_net.py
+++ b/tests/examples/test_rxd_net.py
@@ -5,10 +5,10 @@ import sys
 if '-nogui' not in sys.argv:
     sys.argv.append('-nogui')
 
-from .utils import pkg_setup
+from .utils import pkg_setup, NETPYNE_DIR
 
-
-@pytest.mark.package_data(['examples/rxd_net/', 'mod'])
+package_dir = NETPYNE_DIR + '/examples/rxd_net/'
+@pytest.mark.package_data([package_dir, 'mod'])
 class TestRxdNet:
     def test_init(self, pkg_setup):
         import src.init

--- a/tests/examples/test_saving.py
+++ b/tests/examples/test_saving.py
@@ -5,10 +5,10 @@ if '-nogui' not in sys.argv:
     sys.argv.append('-nogui')
 
 
-from .utils import pkg_setup
+from .utils import pkg_setup, NETPYNE_DIR
 
-
-@pytest.mark.package_data(['examples/saving', None])
+package_dir = NETPYNE_DIR + '/examples/saving/'
+@pytest.mark.package_data([package_dir, None])
 class Test_saving():
     def test_init(self, pkg_setup):
         import src.init

--- a/tests/examples/utils.py
+++ b/tests/examples/utils.py
@@ -1,7 +1,10 @@
 import os
 import pytest
 import sys
+import inspect
+import netpyne
 
+NETPYNE_DIR = '/' + os.path.join(*inspect.getfile(netpyne).split('/')[:-2])
 def compile_neuron_mod_dir(pkg_dir):
     try:
         print('Compiling {}'.format(pkg_dir))
@@ -13,7 +16,6 @@ def compile_neuron_mod_dir(pkg_dir):
         print(' Error compiling support folder mod files')
         print(err)
         return
-
 
 @pytest.fixture
 def pkg_setup(request):


### PR DESCRIPTION
1. bug in `conn.py` from several commits ago causing errors with string representation.
2. issues with dynamic pathing in `tests/...` that preventing users from easily running within a debugger.
     - should this be handled within the utils itself or externally? the dynamic pathing logic is handled externally but to prevent confusion with API, did not change the structure of the code. this can be addressed later.