### PR TITLE
OS.mkdir to OS.makedirs and OSError handeling

### DIFF
--- a/netpyne/batch/utils.py
+++ b/netpyne/batch/utils.py
@@ -28,11 +28,13 @@ def createFolder(folder):
 
     import os
 
+    # If file path does not exist, it will create the file path (parent and sub-directories)
     if not os.path.exists(folder):
         try:
-            os.mkdir(folder)
-        except OSError:
-            print(' Could not create %s' % (folder))
+            os.makedirs(folder)
+        except OSError as e:
+            print('%s: OSError: %s,' % (os.path.abspath(__file__), e))
+            raise SystemExit('Could not create %s' % (folder))
 
 
 # -------------------------------------------------------------------------------

--- a/netpyne/sim/save.py
+++ b/netpyne/sim/save.py
@@ -103,12 +103,15 @@ def saveData(include=None, filename=None, saveLFP=True):
             print(('Copying cfg file %s ... ' % simName))
             source = sim.cfg.backupCfgFile[0]
             targetFolder = sim.cfg.backupCfgFile[1]
-            # make dir
+
+            # make directories required to make the target folder
             try:
-                os.mkdir(targetFolder)
-            except OSError:
+                os.makedirs(targetFolder)
+            except OSError as e:
                 if not os.path.exists(targetFolder):
-                    print(' Could not create target folder: %s' % (targetFolder))
+                    print('%s: OSError: %s,' % (os.path.abspath(__file__), e))
+                    raise SystemExit('Could not create target folder: %s' % (targetFolder))
+                
             # copy file
             targetFile = targetFolder + '/' + simName + '_cfg.py'
             if os.path.exists(targetFile):
@@ -116,13 +119,14 @@ def saveData(include=None, filename=None, saveLFP=True):
                 os.system('rm ' + targetFile)
             os.system('cp ' + source + ' ' + targetFile)
 
-        # create folder if missing
+        # create the missing folder & directory for folder if one or both are missing
         targetFolder = os.path.dirname(sim.cfg.filename)
         if targetFolder and not os.path.exists(targetFolder):
             try:
-                os.mkdir(targetFolder)
-            except OSError:
-                print(' Could not create target folder: %s' % (targetFolder))
+                os.makedirs(targetFolder)
+            except OSError as e:
+                print('%s: OSError: %s,' % (os.path.abspath(__file__), e))
+                raise SystemExit('Could not create target folder: %s' % (targetFolder))
 
         # saving data
         if not include:
@@ -175,13 +179,14 @@ def saveData(include=None, filename=None, saveLFP=True):
                 if hasattr(sim.cfg, 'simLabel') and sim.cfg.simLabel:
                     filePath = os.path.join(sim.cfg.saveFolder, sim.cfg.simLabel + '_data' + timestampStr)
 
-            # create folder if missing
+            # make directories for the target folder if they do not already exist
             targetFolder = os.path.dirname(filePath)
             if targetFolder and not os.path.exists(targetFolder):
                 try:
-                    os.mkdir(targetFolder)
-                except OSError:
-                    print(' Could not create target folder: %s' % (targetFolder))
+                    os.makedirs(targetFolder)
+                except OSError as e:
+                    print('%s: OSError: %s,' % (os.path.abspath(__file__), e))
+                    raise SystemExit('Could not create target folder: %s' % (targetFolder))
 
             # Save to pickle file
             if sim.cfg.savePickle:

--- a/netpyne/specs/netParams.py
+++ b/netpyne/specs/netParams.py
@@ -547,12 +547,13 @@ class NetParams(object):
         folder = filename.split(basename)[0]
         ext = basename.split('.')[1]
 
-        # make dir
+        # make directories if they do not already exist:
         try:
-            os.mkdir(folder)
-        except OSError:
+            os.makedirs(folder)
+        except OSError as e:
             if not os.path.exists(folder):
-                print(' Could not create', folder)
+                print('%s: OSError: %s,' % (os.path.abspath(__file__), e))
+                raise SystemExit('Could not create %s' % (folder))
 
         dataSave = {'net': {'params': self.todict()}}
 

--- a/netpyne/specs/simConfig.py
+++ b/netpyne/specs/simConfig.py
@@ -145,12 +145,13 @@ class SimConfig(object):
         folder = filename.split(basename)[0]
         ext = basename.split('.')[1]
 
-        # make dir
+        # make directories if they do not already exist: 
         try:
-            os.mkdir(folder)
-        except OSError:
+            os.makedirs(folder)
+        except OSError as e:
             if not os.path.exists(folder):
-                print(' Could not create', folder)
+                print('%s: OSError: %s,' % (os.path.abspath(__file__), e))
+                raise SystemExit('Could not create %s' % (folder))
 
         dataSave = {'simConfig': self.__dict__}
 


### PR DESCRIPTION
Changed the os.mkdir file creations in netpyne (batch, specs, and sim) to os.makedirs to create any missing directories for the designated target file creation. Also fixed the OSError handling to point towards file error and exit simulation to ensure system exit handling.