### PR TITLE
Remove saveFileStep

### DIFF
--- a/doc/source/user_documentation.rst
+++ b/doc/source/user_documentation.rst
@@ -1183,6 +1183,65 @@ From a specific section and location, you can record section variables such as v
 	# is equivalent to recording soma.myPP.V in NEURON. 
 	simConfig.recordTraces['VmyPP'] = {'sec': 'soma', 'pointp': 'myPP', 'var': 'V'} 
 
+	## Recording from Synaptic Currents Mechanisms 
+
+	# Example of recording from an excitatory synaptic mechanism
+	# record the 'i' variable (current) from an excitatory synaptic mechanism located
+	# in the middle of the 'dend' section. This is equivalent to recording
+	# dend(0.5).exc._ref_i in NEURON.
+	simConfig.recordTraces['iExcSyn'] = {'sec': 'dend',  'loc': 0.5, 'synMech': 'exc',  'var': 'i'}
+
+	# Example of recording from an inhibitory synaptic mechanism
+	# record the 'i' variable (current) from an inhibitory synaptic mechanism located
+	# at 0.3 of the 'soma' section. This is equivalent to recording
+	# soma(0.3).inh._ref_i in NEURON.
+	simConfig.recordTraces['iInhSyn'] = {'sec': 'soma', 'loc': 0.3, 'synMech': 'inh',  'var': 'i'}
+
+	# Example of recording multiple synaptic currents
+	# Recording synaptic currents
+	simConfig.recordSynapticCurrents = True
+	synaptic_curr = [
+    		('AMPA', 'i'),   # Excitatory synaptic current
+    		('NMDA', 'i'),   # Excitatory synaptic current
+    		('GABA_A', 'i')  # Inhibitory synaptic current
+	]
+	if simConfig.recordSynapticCurrents:
+    	for syn_curr in synaptic_curr:
+        	trace_label = f'i__soma_0__{syn_curr[0]}__{syn_curr[1]}'
+        	simConfig.recordTraces.update({trace_label: {'sec': 'soma_0', 'loc': 0.5, 'mech': syn_curr[0], 'var': syn_curr[1]}})
+
+The names ``'iExcSyn'`` , ``'iInhSyn'`` , ``'AMPA'`` , ``'NMDA'`` , ``'GABA_A'`` are those defined by the user in ``netParams.synMechParams``, and can be found using ``netParams.synMechParams.keys()``. The variables that can be paired with the synaptic mechanism in ``synaptic_curr`` tuples can be found by inspecting the MOD file that is used to define that synaptic mechanism, and the ones that can be recorded are defined as ``RANGE`` type in the MOD file.
+
+Example:
+
+* A synaptic mechanism defined in ``netParams.synMechParamsas`` as ``'AMPA'`` that uses the ``MyExp2SynBB.mod`` template.
+
+	* The user can go to the source ``/mod`` folder, and open the ``MyExp2SynBB.mod`` file, to inspect which variables are defined as ``RANGE``, and those can be recorded.
+	* The user can also modify the variable type, and define as ``RANGE``, and then recompile the mechanism to make it recordable in netpyne.
+
+* Example of variables that can be recorded for the given file
+
+	* The user can record ``'tau1'``, ``'tau2'``, ``'e'``, ``'i'``, ``'g'``, ``'Vwt'``, ``'gmax'``.
+
+ 
+.. code-block:: python
+
+   : $Id: MyExp2SynBB.mod,v 1.4 2010/12/13 21:27:51 samn Exp $ 
+   NEURON {
+   :  THREADSAFE
+     POINT_PROCESS MyExp2SynBB
+     RANGE tau1, tau2, e, i, g, Vwt, gmax
+     NONSPECIFIC_CURRENT i
+   }
+
+Those should be specified in  ``synaptic_curr`` as:
+
+.. code-block:: python
+
+	synaptic_curr = [
+    	('AMPA', 'i'),    # Excitatory synaptic current
+    	('AMPA', 'g'),    # Channel conductance
+	]	
 
 .. _package_functions:
 

--- a/examples/HHTut/src/HHTut.py
+++ b/examples/HHTut/src/HHTut.py
@@ -70,7 +70,6 @@ simConfig.recordStep = 0.1 # Step size in ms to save data (eg. V traces, LFP, et
 
 # Saving
 simConfig.filename = 'HHTut'  # Set file output name
-simConfig.saveFileStep = 1000 # step size in ms to save data to disk
 simConfig.savePickle = False # Whether or not to write spikes etc. to a .mat file
 simConfig.saveJson = True
 

--- a/examples/HybridTut/src/cfg.py
+++ b/examples/HybridTut/src/cfg.py
@@ -23,7 +23,6 @@ cfg.recordStep = 0.025 # Step size in ms to save data (eg. V traces, LFP, etc)
 
 # Saving
 cfg.filename = 'mpiHybridTut'  # Set file output name
-cfg.saveFileStep = 1000 # step size in ms to save data to disk
 cfg.savePickle = False # Whether or not to write spikes etc. to a .mat file
 cfg.saveJson = False # Whether or not to write spikes etc. to a .mat file
 cfg.saveMat = False # Whether or not to write spikes etc. to a .mat file

--- a/examples/M1/src/cfg.py
+++ b/examples/M1/src/cfg.py
@@ -34,7 +34,6 @@ cfg.recordStep = 0.1 # Step size in ms to save data (eg. V traces, LFP, etc)
 
 # Saving
 cfg.filename = 'data/M1_ynorm_izhi'  # Set file output name
-cfg.saveFileStep = 1000 # step size in ms to save data to disk
 cfg.savePickle = False # save to pickle file
 cfg.saveJson = False # save to json file
 cfg.saveMat = False # save to mat file

--- a/examples/RL_arm/params.py
+++ b/examples/RL_arm/params.py
@@ -308,7 +308,6 @@ simConfig.recordStep = 1.0 # Step size in ms to save data (eg. V traces, LFP, et
 
 # Saving
 simConfig.filename = 'simdata'  # Set file output name
-simConfig.saveFileStep = 1000 # step size in ms to save data to disk
 simConfig.savePickle = True # Whether or not to write spikes etc. to a .mat file
 simConfig.saveJson = False # Whether or not to write spikes etc. to a .mat file
 simConfig.saveMat = False # Whether or not to write spikes etc. to a .mat file

--- a/netpyne/tests/validate_tests.py
+++ b/netpyne/tests/validate_tests.py
@@ -69,7 +69,6 @@ class RunNetPyneTests(object):
         #
         # # Saving
         # simConfigParams.simConfig.saveJson=1
-        # simConfigParams.simConfig.saveFileStep = simConfigParams.simConfig.dt # step size in ms to save data to disk
         #
         # self.paramsMap["simConfig"]["durationTest"].append(simConfigParams)
 

--- a/sdnotes.org
+++ b/sdnotes.org
@@ -7135,7 +7135,6 @@ simConfig.recordStep = 0.1 # Step size in ms to save data (eg. V traces, LFP, et
 # Saving
 simConfig.filename = 'HHTut'  # Set file output name
 #simConfig.Label = 'sim1'
-simConfig.saveFileStep = 1000 # step size in ms to save data to disk
 simConfig.savePickle = False # Whether or not to write spikes etc. to a .mat file
 simConfig.recordStim = True
 simConfig.saveJson = True # save to json file


### PR DESCRIPTION
This pull request removes the `saveFileStep` parameter and all its references from the codebase. This change addresses issue #423.