### PR TITLE
Bug fix in scalebar - removing the use of the minimumdescent argument in the call to TextArea

### DIFF
--- a/netpyne/support/scalebar.py
+++ b/netpyne/support/scalebar.py
@@ -53,7 +53,7 @@ try:
                 bars.add_artist(Rectangle((0, 0), 0, sizey, ec=barcolor, lw=barwidth, fc="none"))
 
             if sizex and labelx:
-                self.xlabel = TextArea(labelx, minimumdescent=False)
+                self.xlabel = TextArea(labelx)
                 bars = VPacker(children=[bars, self.xlabel], align="center", pad=0, sep=sep)
             if sizey and labely:
                 self.ylabel = TextArea(labely)


### PR DESCRIPTION
Calls to `sim.analysis.plotTraces(...)` crashes with 

```
Traceback (most recent call last):
  File "/Users/christian/opt/anaconda3/lib/python3.9/site-packages/netpyne/analysis/utils.py", line 87, in wrapper
    return function(*args, **kwargs)
  File "/Users/christian/opt/anaconda3/lib/python3.9/site-packages/netpyne/analysis/traces.py", line 400, in plotTraces
    plotFigPerTrace(cellGids)
  File "/Users/christian/opt/anaconda3/lib/python3.9/site-packages/netpyne/analysis/traces.py", line 317, in plotFigPerTrace
    addScaleBar()
  File "/Users/christian/opt/anaconda3/lib/python3.9/site-packages/netpyne/analysis/traces.py", line 200, in addScaleBar
    add_scalebar(
  File "/Users/christian/opt/anaconda3/lib/python3.9/site-packages/netpyne/support/scalebar.py", line 103, in add_scalebar
    sb = AnchoredScaleBar(ax.transData, **kwargs)
  File "/Users/christian/opt/anaconda3/lib/python3.9/site-packages/netpyne/support/scalebar.py", line 63, in __init__
    self.xlabel = TextArea(labelx, minimumdescent=False)
TypeError: __init__() got an unexpected keyword argument 'minimumdescent'
```

As per Matplotlib [API changes for version 3.4.3:](https://matplotlib.org/3.4.3/api/api_changes.html):

    minimumdescent parameter/property of TextArea

    [offsetbox.TextArea](https://matplotlib.org/3.4.3/api/offsetbox_api.html#matplotlib.offsetbox.TextArea) 
    has behaved as if minimumdescent was always True (regardless of the value to which it was set) since 
    Matplotlib 1.3, so the parameter/property is deprecated.

This argument has been removed from the API of the current version of Matplotlib, causing this code to crash.
