### PR TITLE
feedback for expanse scripts, moved {env} {res} {custom}, removed the `source ./bashrc` since that can be handled in {custom}

### DIFF
--- a/netpyne/batchtools/search.py
+++ b/netpyne/batchtools/search.py
@@ -225,6 +225,7 @@ constructor_tuples = {
     ('sh', 'sfs' ): constructors(runtk.dispatchers.SFSDispatcher , submits.SHSubmitSFS),
 }#TODO, just say "socket"?
 
+
 """
 some shim functions before ray_search
 """

--- a/netpyne/batchtools/submits.py
+++ b/netpyne/batchtools/submits.py
@@ -179,9 +179,8 @@ class SlurmSubmit(Submit):
 #SBATCH --mail-user={email}
 #SBATCH --mail-type=end
 export JOBID=$SLURM_JOB_ID
-{res}
+{env}
 {custom}
-source ~/.bashrc
 cd {project_path}
 {command}
 wait
@@ -227,8 +226,8 @@ class SlurmSubmitSFS(SlurmSubmit):
 export JOBID=$SLURM_JOB_ID
 export OUTFILE="{output_path}/{label}.out"
 export SGLFILE="{output_path}/{label}.sgl"
+{env}
 {custom}
-source ~/.bashrc
 cd {project_path}
 {command}
 wait
@@ -254,8 +253,8 @@ class SlurmSubmitSOCK(SlurmSubmit):
 #SBATCH --mail-type=end
 export JOBID=$SLURM_JOB_ID
 export SOCNAME="{sockname}"
+{env}
 {custom}
-source ~/.bashrc
 cd {project_path}
 {command}
 wait
@@ -264,3 +263,4 @@ wait
                       runtk.STDOUT: '{output_path}/{label}.run',
                       runtk.SOCKET: '{sockname}'
                       }
+


### PR DESCRIPTION
feedback for expanse scripts, moved {env} {res} {custom}, removed the `source ./bashrc` since that can be handled in {custom}

also note-- new test for 3.7 failing d/t external error "functools" import