### PR TITLE
ci(py): drop 3.7, add 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        #python-version: [2.7, 3.7]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
3.7 is EOL, 3.12 is now active:

https://devguide.python.org/versions/