### PR TITLE
Fix crash when saving with cfg.saveMat: Dict resolves special attributes from its keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - fixed crash where stimTargetParams provided with no `loc` (for IClamp and other cases)
 - restore proper functioning of `cfg.saveLFPPops` and `cfg.saveDipolePops` as `True`, and their combined use
 - fixed crash in `modifySynMechs()`
+- fixed crash when saving with `cfg.saveMat`, caused by `Dict` resolving special attributes (e.g. `__deepcopy__`) from its keys
 
 # Version 1.1.1
 

--- a/netpyne/specs/dicts.py
+++ b/netpyne/specs/dicts.py
@@ -37,6 +37,14 @@ class Dict(dict):
             # Throws exception if not in prototype chain
             return object.__getattribute__(self, k)
         except AttributeError:
+            # Special ("dunder") attributes are probed by the interpreter and by the
+            # standard library, e.g. copy.deepcopy() looks for __deepcopy__ on the
+            # instance. Falling through to item access for those would create the key
+            # via __missing__ and hand back a Dict, which the caller then uses as if it
+            # were the special method itself (raising e.g. "'Dict' object is not
+            # callable"), and silently leaves the bogus key behind in the data.
+            if k.startswith('__') and k.endswith('__'):
+                raise
             try:
                 return self[k]
             except KeyError:

--- a/tests/unit/test_dicts.py
+++ b/tests/unit/test_dicts.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pytest
+import sys
+from copy import deepcopy
+from netpyne import specs
+if '-nogui' not in sys.argv:
+    sys.argv.append('-nogui')
+
+@pytest.fixture()
+def pkg_setup():
+    pass
+
+class TestDict():
+
+    def test_deepcopy(self, pkg_setup):
+        # deepcopy() probes the instance for a __deepcopy__ attribute; Dict used to
+        # answer that probe with an auto-created entry, which then failed as
+        # "'Dict' object is not callable" (e.g. when saving with cfg.saveMat)
+        d = specs.Dict({'secs': {'soma': {'geom': {'diam': 18.8, 'L': 18.8}}}})
+        copied = deepcopy(d)
+
+        assert copied == d, "Dict: deepcopy did not preserve the contents"
+        assert isinstance(copied, specs.Dict), "Dict: deepcopy did not preserve the type"
+        assert isinstance(copied.secs.soma.geom, specs.Dict), "Dict: deepcopy did not preserve the type of nested dicts"
+        assert copied.secs.soma.geom.diam == 18.8, "Dict: deepcopy did not preserve nested values"
+
+    def test_deepcopy_is_independent_of_original(self, pkg_setup):
+        d = specs.Dict({'secs': {'soma': {'geom': {'diam': 18.8}}}})
+        copied = deepcopy(d)
+        copied.secs.soma.geom.diam = 99.9
+
+        assert d.secs.soma.geom.diam == 18.8, "Dict: deepcopy shares nested dicts with the original"
+
+    def test_deepcopy_leaves_original_untouched(self, pkg_setup):
+        # the failed lookup used to store a '__deepcopy__' key in the data itself
+        d = specs.Dict({'diam': 18.8})
+        deepcopy(d)
+
+        assert list(d.keys()) == ['diam'], "Dict: deepcopy added spurious keys to the original"
+
+    def test_deepcopy_odict_of_dicts(self, pkg_setup):
+        # this is the shape of cell.secs
+        secs = specs.ODict([('soma', specs.Dict({'geom': {'diam': 18.8}}))])
+        copied = deepcopy(secs)
+
+        assert isinstance(copied, specs.ODict), "ODict: deepcopy did not preserve the type"
+        assert isinstance(copied['soma'], specs.Dict), "ODict: deepcopy did not preserve the type of nested dicts"
+        assert copied['soma'].geom.diam == 18.8, "ODict: deepcopy did not preserve nested values"
+
+    def test_missing_special_attribute_raises(self, pkg_setup):
+        d = specs.Dict({'diam': 18.8})
+
+        with pytest.raises(AttributeError):
+            getattr(d, '__deepcopy__')
+        assert list(d.keys()) == ['diam'], "Dict: probing a special attribute added a key"
+
+    def test_converting_to_numpy_array(self, pkg_setup):
+        # scipy.io.savemat() converts the values it is given with numpy, which probes
+        # __array_struct__; answering that probe used to raise "invalid __array_struct__"
+        # and was the failure hit when saving the HHTut example with cfg.saveMat
+        d = specs.Dict({'diam': 18.8})
+
+        assert np.asarray(d).shape == np.asarray({'diam': 18.8}).shape, "Dict: does not convert to a numpy array like a plain dict"
+
+    def test_missing_attribute_still_creates_nested_dicts(self, pkg_setup):
+        # dot notation on a non-existing (non-special) key must keep working as before
+        d = specs.Dict()
+        d.secs.soma.geom.diam = 18.8
+
+        assert isinstance(d.secs, specs.Dict), "Dict: dot notation no longer creates nested dicts"
+        assert d['secs']['soma']['geom']['diam'] == 18.8, "Dict: dot notation no longer sets nested values"


### PR DESCRIPTION
This PR proposes a fix for the `cfg.saveMat` crash reported in #843, where `specs.Dict` resolves special attributes such as `__deepcopy__` from its own keys instead of reporting that it does not have them (Fixes #843). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/445. You can sign in with your GitHub ID to claim ownership of the project.

## What goes wrong

`Dict.__getattr__` falls back to item access when an attribute is not found, and `Dict.__missing__` creates missing keys on demand. Together they mean that *every* attribute lookup on a `Dict` succeeds — including the special-attribute probes that the interpreter and the standard library make on arbitrary objects. `copy.deepcopy()` probes `getattr(x, '__deepcopy__', None)`, so a `Dict` hands it a freshly created empty `Dict`, and `deepcopy` then calls that. This is the `TypeError: 'Dict' object is not callable` in #843, raised from `netpyne/sim/save.py:233`. The failed probe also leaves the invented key behind in the user's data.

On the current `development` HEAD (3f50b512):

```
$ python -c "
from copy import deepcopy
from netpyne import specs
d = specs.Dict({'secs': {'soma': {'geom': {'diam': 18.8}}}})
try:
    deepcopy(d)
except TypeError as e:
    print('deepcopy ->', e)
print('d is now ->', d)
"
deepcopy -> 'Dict' object is not callable
d is now -> {secs: {soma: {geom: {diam: 18.8}}}, __deepcopy__: {}}
```

The same root cause produces the second failure the reporter mentions — "I have tested SaveMat with the HHTut network but it produces a completely different error". `scipy.io.savemat` converts the values it is given with numpy, and `np.asarray` probes `__array_struct__`; a `Dict` answers that probe too, so numpy rejects the object outright. From `examples/HHTut` on the same HEAD:

```
$ python -c "
import sys; sys.argv.append('-nogui')
from netpyne import sim
cfg, netParams = sim.loadFromIndexFile('index.npjson')
cfg.duration, cfg.analysis, cfg.saveJson, cfg.saveMat = 100, {}, False, True
sim.createSimulateAnalyze(netParams=netParams, simConfig=cfg)
"
  File ".../scipy/io/matlab/_mio5.py", line 470, in to_writeable
    return np.asarray(source)
ValueError: invalid __array_struct__
```

That one is worse than a plain crash, because `savemat` has already started writing: it leaves a 2.5 MB `HHTut_data.mat` on disk that loads without complaint but is missing `simData` — the simulation results themselves. It also lines up with the note already in `netpyne/sim/load.py:357-358` ("`cell.secs` should probably be deepcopied ... but currently deepcopying of ODict fails"), since `cell.secs` is an `ODict` of `Dict`s and fails for exactly this reason.

## The change

`Dict.__getattr__` now re-raises `AttributeError` for dunder names rather than falling through to item access, so a probe for a special method gets an honest answer and Python's normal protocols take over from there. This is the same problem the existing `_ipython` guard in `__missing__` already handles for one particular prober, generalised to the rest of them.

Nothing else changes: ordinary dot notation still auto-creates nested `Dict`s (`d.secs.soma.geom.diam = 18.8`), plain item access still auto-creates keys, and `deepcopy` now returns an independent copy that preserves the nested `Dict` / `ODict` types and dot access. The last test in the new file is a control for exactly that, and it is the one test that already passes on the unmodified tree.

## Verification

With the change applied, the `examples/HHTut` snippet above runs to completion and writes a `HHTut_data.mat` that `scipy.io.loadmat` reads back with `net`, `simConfig` **and** `simData` present.

`tests/unit/test_dicts.py` adds seven tests covering `deepcopy` of a `Dict` and of an `ODict` of `Dict`s, deep independence from the original, the original not being polluted, the numpy conversion, `AttributeError` on a missing dunder, and the auto-creation control. Six of the seven fail on the unmodified tree:

```
$ git checkout upstream/development -- netpyne/specs/dicts.py
$ pytest tests/unit/test_dicts.py -q
6 failed, 1 passed in 1.89s

$ git checkout HEAD -- netpyne/specs/dicts.py
$ pytest tests/unit/test_dicts.py -q
7 passed in 1.77s
```

I ran the whole suite the way `tests/test.sh` does — each entry separately — before and after the change. The set of failing tests is byte-identical: 11 both times, all of them pre-existing in my environment and caused by NEURON mechanisms I have not compiled (`AttributeError: 'hoc.HocObject'`, `RuntimeError: hoc`) plus some missing example data. Nothing new goes red, and the passing count moves from 50 to 57 — the seven added tests.

## How this was managed

We imported this repository's issues and pull requests into an agile board and used it to track the work: the story for this change is https://eastagiletracker.com/projects/445/stories/395997, and the board itself, 880 stories imported from your issues and pull requests, is at https://eastagiletracker.com/projects/445.

![board](https://raw.githubusercontent.com/eastagiletracker/netpyne/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
